### PR TITLE
Added url attribute to SearchResults

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ AnimeSearch(query)
 
 returns an array of results via .results
 
+AnimeSearchResult.url
 AnimeSearchResult.image_url
 AnimeSearchResult.title
 AnimeSearchResult.synopsis
@@ -143,6 +144,7 @@ MangaSearch(query)
 
 returns an array of results via .results
 
+MangaSearchResult.url
 MangaSearchResult.image_url
 MangaSearchResult.title
 MangaSearchResult.synopsis

--- a/mal/anime_search.py
+++ b/mal/anime_search.py
@@ -3,8 +3,8 @@ from mal.search import _Search, _SearchResult
 
 
 class AnimeSearchResult(_SearchResult):
-    def __init__(self, image_url, title, synopsis, media_type, episodes, score):
-        super().__init__(image_url, title, synopsis, media_type, score)
+    def __init__(self, url, image_url, title, synopsis, media_type, episodes, score):
+        super().__init__(url, image_url, title, synopsis, media_type, score)
         self.episodes = episodes
 
 
@@ -25,6 +25,7 @@ class AnimeSearch(_Search):
             for tr in trs[1:]:
                 tds = tr.find_all("td")
                 results.append(AnimeSearchResult(
+                    url=tds[0].find("a")["href"],
                     image_url=tds[0].find("img")["data-src"],
                     title=tds[1].find("strong").text.strip(),
                     synopsis=self._remove_suffix(tds[1].find("div", {"class": "pt4"}).text.strip(), "read more."),

--- a/mal/manga_search.py
+++ b/mal/manga_search.py
@@ -3,8 +3,8 @@ from mal.search import _Search, _SearchResult
 
 
 class MangaSearchResult(_SearchResult):
-    def __init__(self, image_url, title, synopsis, media_type, volumes, score):
-        super().__init__(image_url, title, synopsis, media_type, score)
+    def __init__(self, url, image_url, title, synopsis, media_type, volumes, score):
+        super().__init__(url, image_url, title, synopsis, media_type, score)
         self.volumes = volumes
 
 
@@ -25,6 +25,7 @@ class MangaSearch(_Search):
             for tr in trs[1:]:
                 tds = tr.find_all("td")
                 results.append(MangaSearchResult(
+                    url=tds[0].find("a")["href"],
                     image_url=tds[0].find("img")["data-src"],
                     title=tds[1].find("strong").text.strip(),
                     synopsis=self._remove_suffix(tds[1].find("div", {"class": "pt4"}).text.strip(), "read more."),

--- a/mal/search.py
+++ b/mal/search.py
@@ -3,7 +3,8 @@ from mal.base import _Base
 
 
 class _SearchResult:
-    def __init__(self, image_url, title, synopsis, media_type, score):
+    def __init__(self, url, image_url, title, synopsis, media_type, score):
+        self.url = url
         self.image_url = image_url
         self.title = title
         self.synopsis = synopsis

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mal-api",
-    version="0.2.2",
+    version="0.2.3",
     description="A local MyAnimeList API ",
     license="MIT",
     long_description=long_description,


### PR DESCRIPTION
I thought it would be great, if you search for an anime, that you can get instantly the url of it because at moment you can only access an anime by his id, which you can't access. So I've added the url attribute to AnimeSearchResults because there you can get anime id's if you want or just use the url.