### PR TITLE
Advance search type support for both Manga and Anime search.

### DIFF
--- a/mal/__init__.py
+++ b/mal/__init__.py
@@ -1,8 +1,23 @@
-from mal._anime import Anime
+from mal._anime import Anime, AnimeType
 from mal._anime_search import AnimeSearch
-from mal._manga import Manga
+from mal._manga import Manga, MangaType
 from mal._manga_search import MangaSearch
 from mal._anime import AnimeCharacterResult, AnimeStaffResult
 from mal._anime_search import AnimeSearchResult
 from mal._manga import MangaCharacterResult
 from mal._manga_search import MangaSearchResult
+
+
+__all__ = [
+    'Anime',
+    'AnimeType',
+    'AnimeSearch',
+    'Manga',
+    'MangaType',
+    'MangaSearch',
+    'AnimeCharacterResult', 
+    'AnimeStaffResult',
+    'AnimeSearchResult',
+    'MangaCharacterResult',
+    "MangaSearchResult"
+]

--- a/mal/_anime.py
+++ b/mal/_anime.py
@@ -1,8 +1,17 @@
 from typing import Optional, List, Dict
+from enum import IntEnum
 
 from mal import config, _base
 from mal._mal import _MAL
 
+
+class AnimeType(IntEnum):
+    TV =        1
+    OVA =       2
+    MOVIE =     3
+    SPECIAL =   4
+    ONA =       5
+    MUSIC =     6
 
 class AnimeCharacterResult:
     def __init__(self, name, role, voice_actor):

--- a/mal/_anime_search.py
+++ b/mal/_anime_search.py
@@ -58,11 +58,12 @@ class AnimeSearchResult(_SearchResult):
 
 
 class AnimeSearch(_Search):
-    def __init__(self, query: str, timeout: int = config.TIMEOUT):
+    def __init__(self, query: str, type: str=None, timeout: int = config.TIMEOUT):
         """
         Anime search by query
         """
-        super().__init__(query, "anime", timeout)
+        # Add advanced search type for anime
+        super().__init__(query, type, "anime", timeout)
 
     def reload(self) -> None:
         """

--- a/mal/_manga.py
+++ b/mal/_manga.py
@@ -3,7 +3,15 @@ from typing import Optional, List, Dict
 from mal import config, _base
 from mal._mal import _MAL
 
-
+class MangaType:
+    MANGA       = 1
+    ONE_SHOT    = 2
+    DOUJINSHI   = 3
+    LIGHT_NOVEL = 4
+    NOVER       = 5
+    MANHWAW     = 6
+    MANHUA      = 7
+    
 class MangaCharacterResult:
     def __init__(self, name, role):
         """

--- a/mal/_manga_search.py
+++ b/mal/_manga_search.py
@@ -58,11 +58,11 @@ class MangaSearchResult(_SearchResult):
 
 
 class MangaSearch(_Search):
-    def __init__(self, query: str, timeout: int = config.TIMEOUT):
+    def __init__(self, query: str, type: str=None, timeout: int = config.TIMEOUT):
         """
         Manga search by query
         """
-        super().__init__(query, "manga", timeout)
+        super().__init__(query, type, "manga", timeout)
 
     def reload(self) -> None:
         """

--- a/mal/_search.py
+++ b/mal/_search.py
@@ -123,7 +123,7 @@ class _Search(_Base):
                         mal_type
                     )[_type.lower()]
                 except KeyError: 
-                    warnings.warn("Type: %s is not a valid type." % (_type))
+                    warnings.warn("Invalid Advance search type.")
                     t = None
             else:
                 # If not instance of string then return the value

--- a/mal/config.py
+++ b/mal/config.py
@@ -1,2 +1,21 @@
 MAL_ENDPOINT = "https://myanimelist.net/"
 TIMEOUT = 5
+MAL_ADVANCED_SEARCH = {
+    "anime": {
+        "tv":       1,
+        "ova":      2,
+        "movie":    3,
+        "special":  4,
+        "ona":      5,
+        "music":    6
+    },
+    "manga": {
+        "manga":        1,
+        "one-shot":     2,
+        "doujinshi":    3,
+        "light novel":  4,
+        "novel":        5,
+        "manhwa":       6,
+        "manhua":       7
+    }
+}


### PR DESCRIPTION
I've been using & searching through MAL for several months / years. I stumbled upon when searching `one piece`, the first result is a movie which is basically not what I want when using this library. I found out that you can use the advance search to filter all types of Anime / Manga such as TVs, Movies, OVAs, etc.

This is made possible using the type field from the query.
`/?q=one%20piece&type=1`

I also made some little tweak with `__init__` file.