### PR TITLE
Edit BeautifulSoup call to expect MAL in utf-8 encoded format

### DIFF
--- a/mal/_base.py
+++ b/mal/_base.py
@@ -40,4 +40,4 @@ class _Base:
 
     def _parse_url(self, url) -> Any:
         page_response = requests.get(url, timeout=self.timeout)
-        return BeautifulSoup(page_response.content, "html.parser")
+        return BeautifulSoup(page_response.content, "html.parser", from_encoding='utf-8')


### PR DESCRIPTION
The BeautifulSoup html.parser automatically guesses the MAL' pages encoding to be 'macroman', which completely breaks the representation of Japanese lettering in python3 (since all strings are assumed to be utf-8 by default in python).

This breaks the .title_japanese() attribute of the class 'Anime'. A possible workaround would be adding an additional line stating 

return super().title_japanese.encode('macroman').decode('utf-8') 

In line 188 of _anime.py
But this combats the symptom, not the issue.